### PR TITLE
update of CC Logger

### DIFF
--- a/openidl-chaincode/chaincode/openidl/consent_controller.go
+++ b/openidl-chaincode/chaincode/openidl/consent_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 )
 
 /**
@@ -112,12 +113,12 @@ func (this *openIDLCC) UpdateConsentStatus(stub shim.ChaincodeStubInterface, arg
 		return shim.Error(errors.New("UpdateConsentStatus: Error during json.Unmarshal").Error())
 	}
 
-	if consent.DataCallID == "" || consent.DataCallVersion == "" || consent.CarrierID == ""  {
+	if consent.DataCallID == "" || consent.DataCallVersion == "" || consent.CarrierID == "" {
 		return shim.Error("DataCallID or DataCallVersion or CarrierID can't be empty")
 	}
 
 	pks := []string{CONSENT_PREFIX, consent.DataCallID, consent.DataCallVersion, consent.CarrierID}
-	consentKey, _ := stub.CreateCompositeKey(CONSENT_DOCUMENT_TYPE, pks) 
+	consentKey, _ := stub.CreateCompositeKey(CONSENT_DOCUMENT_TYPE, pks)
 
 	logger.Debug("Get Consent from World State")
 	consentData, _ := stub.GetState(consentKey)
@@ -139,9 +140,9 @@ func (this *openIDLCC) UpdateConsentStatus(stub shim.ChaincodeStubInterface, arg
 
 		consentDataAsBytes, _ := json.Marshal(cc)
 		err = stub.PutState(consentKey, consentDataAsBytes)
-				if err != nil {
-					logger.Error("Error commiting the cosent status")
-					return shim.Error("Error commiting the consent status")
+		if err != nil {
+			logger.Error("Error commiting the cosent status")
+			return shim.Error("Error commiting the consent status")
 		}
 
 		return shim.Success(nil)

--- a/openidl-chaincode/chaincode/openidl/data_call_controller.go
+++ b/openidl-chaincode/chaincode/openidl/data_call_controller.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	pb "github.com/hyperledger/fabric/protos/peer"
 	"strconv"
 	"time"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 )
 
 // generateVersion is a helper function for generating a version number.
@@ -79,7 +81,7 @@ func (this *openIDLCC) CreateDataCall(stub shim.ChaincodeStubInterface, args str
 	toggleDataCallCount := ToggleDataCallCount{"", dataCall.Status}
 	datacallIssueLogAsBytes, _ := json.Marshal(toggleDataCallCount)
 	dataCallCountAsBytes := this.ToggleDataCallCount(stub, string(datacallIssueLogAsBytes))
-	logger.Info("The reply from toggle is ", dataCallCountAsBytes)	
+	logger.Info("The reply from toggle is ", dataCallCountAsBytes)
 
 	return shim.Success(nil)
 
@@ -142,7 +144,7 @@ func (this *openIDLCC) ListDataCallsByCriteria(stub shim.ChaincodeStubInterface,
 	elapsedTime := time.Since(startTime)
 	logger.Info("RESPONSE META DATA ", responseMetadata.FetchedRecordsCount)
 	logger.Info("Time consumed to get Data Calls", elapsedTime)
-	defer resultsIterator.Close()	
+	defer resultsIterator.Close()
 	if err != nil {
 		logger.Error("Failed to get state for all the data calls")
 		return shim.Error("Failed to get state for all the data calls")
@@ -366,15 +368,14 @@ func (this *openIDLCC) SaveNewDraft(stub shim.ChaincodeStubInterface, args strin
 	}
 	logger.Debug("SaveNewDraft: Latest Datacall saved!")
 
-	if(currentDataCall.Status != dataCalls[0].Status){
+	if currentDataCall.Status != dataCalls[0].Status {
 		//change the count of the statuses
 		logger.Info("Toggling ", currentDataCall.Status, " and ", dataCalls[0].Status)
 		toggleDataCallCount := ToggleDataCallCount{dataCalls[0].Status, currentDataCall.Status}
 		datacallIssueLogAsBytes, _ := json.Marshal(toggleDataCallCount)
 		dataCallCountAsBytes := this.ToggleDataCallCount(stub, string(datacallIssueLogAsBytes))
-		logger.Info("The reply from toggle is ", dataCallCountAsBytes)	
+		logger.Info("The reply from toggle is ", dataCallCountAsBytes)
 	}
-
 
 	return shim.Success(nil)
 
@@ -613,13 +614,13 @@ func (this *openIDLCC) UpdateDataCall(stub shim.ChaincodeStubInterface, args str
 
 	_ = stub.SetEvent(SET_EXTRACTION_PATTERN_EVENT, extPatternResponseAsBytes)
 
-	if(dataCall.Status != prevDataCall.Status){
+	if dataCall.Status != prevDataCall.Status {
 		//change the count of the statuses
 		logger.Info("Toggling ", dataCall.Status, " and ", prevDataCall.Status)
 		toggleDataCallCount := ToggleDataCallCount{prevDataCall.Status, dataCall.Status}
 		datacallIssueLogAsBytes, _ := json.Marshal(toggleDataCallCount)
 		dataCallCountAsBytes := this.ToggleDataCallCount(stub, string(datacallIssueLogAsBytes))
-		logger.Info("The reply from toggle is ", dataCallCountAsBytes)	
+		logger.Info("The reply from toggle is ", dataCallCountAsBytes)
 	}
 
 	return shim.Success(nil)
@@ -708,15 +709,15 @@ func (this *openIDLCC) IssueDataCall(stub shim.ChaincodeStubInterface, args stri
 			return shim.Error("Error commiting the previous DataCall")
 		}
 
-		if(dataCall.Status != prevDataCall.Status){
+		if dataCall.Status != prevDataCall.Status {
 			//change the count of the statuses
 			logger.Info("Toggling ", dataCall.Status, " and ", prevDataCall.Status)
 			toggleDataCallCount := ToggleDataCallCount{prevDataCall.Status, dataCall.Status}
 			datacallIssueLogAsBytes, _ := json.Marshal(toggleDataCallCount)
 			dataCallCountAsBytes := this.ToggleDataCallCount(stub, string(datacallIssueLogAsBytes))
-			logger.Info("The reply from toggle is ", dataCallCountAsBytes)	
+			logger.Info("The reply from toggle is ", dataCallCountAsBytes)
 		}
-	
+
 	}
 
 	return shim.Success(nil)
@@ -805,15 +806,13 @@ func (this *openIDLCC) toggleDataCallCount(stub shim.ChaincodeStubInterface, arg
 // 		return shim.Error("Incorrect number of arguments!!")
 // 	}
 
-	
-	
 // 	var pks []string = []string{DATA_CALL_PREFIX, "COUNT", "10"}
 // 	countPatternKey, _ := stub.CreateCompositeKey(DOCUMENT_TYPE, pks)
-	
+
 // 	args3 := map[string]int{"ISSUED": 1,"DRAFT": 0, "CANCELLED": 0}
 // 	var dataCallCount = DataCallCount{counts: args3}
 // 	fmt.Println("REACHED INSIDE 3 " + countPatternKey)
-	
+
 // 	logger.Info("REACHED INSIDE 4 ", dataCallCount)
 
 // 	prevDataCallAsBytes, _ := json.Marshal(dataCallCount)
@@ -846,11 +845,9 @@ func (this *openIDLCC) toggleDataCallCount(stub shim.ChaincodeStubInterface, arg
 // 	}
 // 	logger.Info("GOT THE RESPONSE ", prevDataCall)
 
-
 // 	return shim.Success(nil)
 
 // }
-
 
 func (this *openIDLCC) ToggleDataCallCount(stub shim.ChaincodeStubInterface, args string) pb.Response {
 	logger.Debug("ToggleDataCallCount: enter")
@@ -868,25 +865,24 @@ func (this *openIDLCC) ToggleDataCallCount(stub shim.ChaincodeStubInterface, arg
 	}
 	logger.Info("Unmarshalled object ", toggleDataCallCount)
 
-
 	getDataCallCount := GetDataCallCount{"123456", "1"}
 	datacallIssueLogAsBytes, _ := json.Marshal(getDataCallCount)
 	dataCallCountAsBytes := this.GetDataCallCount(stub, string(datacallIssueLogAsBytes))
 	var dataCallCount DataCallCount
 	err = json.Unmarshal(dataCallCountAsBytes.Payload, &dataCallCount)
-	
+
 	logger.Info("The retrieved data is ", dataCallCount)
 
 	if toggleDataCallCount.OriginalStatus == "ISSUED" {
-		dataCallCount.ISSUED = dataCallCount.ISSUED - 1 
+		dataCallCount.ISSUED = dataCallCount.ISSUED - 1
 	} else if toggleDataCallCount.OriginalStatus == "DRAFT" {
 		dataCallCount.DRAFT = dataCallCount.DRAFT - 1
 	} else if toggleDataCallCount.OriginalStatus == "CANCELLED" {
 		dataCallCount.CANCELLED = dataCallCount.CANCELLED - 1
 	}
-	
+
 	if toggleDataCallCount.NewStatus == "ISSUED" {
-		dataCallCount.ISSUED = dataCallCount.ISSUED + 1 
+		dataCallCount.ISSUED = dataCallCount.ISSUED + 1
 	} else if toggleDataCallCount.NewStatus == "DRAFT" {
 		dataCallCount.DRAFT = dataCallCount.DRAFT + 1
 	} else if toggleDataCallCount.NewStatus == "CANCELLED" {
@@ -972,7 +968,6 @@ func (this *openIDLCC) UpdateDataCallCount(stub shim.ChaincodeStubInterface, arg
 	return shim.Success(nil)
 
 }
-
 
 // SearchDataCalls retrives all data calls that match given criteria. If startindex and pageSize are not provided,
 // this method returns the complete list of data calls. If version = latest, the it returns only latest version of a data call

--- a/openidl-chaincode/chaincode/openidl/data_call_controller_test.go
+++ b/openidl-chaincode/chaincode/openidl/data_call_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
+	logger "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/openidl-chaincode/chaincode/openidl/data_call_log_controller.go
+++ b/openidl-chaincode/chaincode/openidl/data_call_log_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 	//"time"
 )
 

--- a/openidl-chaincode/chaincode/openidl/delete_state_controller.go
+++ b/openidl-chaincode/chaincode/openidl/delete_state_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 )
 
 func (this *openIDLCC) ResetWorldState(stub shim.ChaincodeStubInterface) pb.Response {

--- a/openidl-chaincode/chaincode/openidl/delete_state_controller_test.go
+++ b/openidl-chaincode/chaincode/openidl/delete_state_controller_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	logger "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 //Test for ResetWorldState

--- a/openidl-chaincode/chaincode/openidl/extraction_patters_controller.go
+++ b/openidl-chaincode/chaincode/openidl/extraction_patters_controller.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"strconv"
+	logger "github.com/sirupsen/logrus"
 )
 
 // creates extraction patten definition
@@ -26,15 +28,15 @@ func (this *openIDLCC) CreateExtractionPattern(stub shim.ChaincodeStubInterface,
 		return shim.Error("DbType cant not be empty!!")
 	} else if extractionPatten.ViewDefinition.Map == "" || extractionPatten.ViewDefinition.Reduce == "" {
 		return shim.Error("ViewDefinition cant be empty!!")
-	}   else if extractionPatten.PremiumFromDate == "" {  
-        return shim.Error("PremiumFromDate cannot not be Empty")
-    } else if extractionPatten.LossFromDate == "" {  
-        return shim.Error("LossFromDate cannot not be Empty")
-    } else if extractionPatten.Jurisdiction == "" {  
-        return shim.Error("Jurisdiction cannot not be Empty")
-    } else if extractionPatten.Insurance == "" {  
-        return shim.Error("Insurance cannot not be Empty")
-    }
+	} else if extractionPatten.PremiumFromDate == "" {
+		return shim.Error("PremiumFromDate cannot not be Empty")
+	} else if extractionPatten.LossFromDate == "" {
+		return shim.Error("LossFromDate cannot not be Empty")
+	} else if extractionPatten.Jurisdiction == "" {
+		return shim.Error("Jurisdiction cannot not be Empty")
+	} else if extractionPatten.Insurance == "" {
+		return shim.Error("Insurance cannot not be Empty")
+	}
 	if err != nil {
 		logger.Error("CreateExtractionPattern: Error during json.Unmarshal: ", err)
 		return shim.Error(errors.New("CreateExtractionPattern: Error during json.Unmarshal").Error())
@@ -83,14 +85,14 @@ func (this *openIDLCC) UpdateExtractionPattern(stub shim.ChaincodeStubInterface,
 		return shim.Error("DbType should not be Empty")
 
 	} else if extractionPatten.PremiumFromDate == "" {
-        return shim.Error("PremiumFromDate cannot not be Empty")
-    } else if extractionPatten.LossFromDate == "" {  
-        return shim.Error("LossFromDate cannot not be Empty")
-    } else if extractionPatten.Jurisdiction == "" {  
-        return shim.Error("Jurisdiction cannot not be Empty")
-    } else if extractionPatten.Insurance == "" {  
-        return shim.Error("Insurance cannot not be Empty")
-    }
+		return shim.Error("PremiumFromDate cannot not be Empty")
+	} else if extractionPatten.LossFromDate == "" {
+		return shim.Error("LossFromDate cannot not be Empty")
+	} else if extractionPatten.Jurisdiction == "" {
+		return shim.Error("Jurisdiction cannot not be Empty")
+	} else if extractionPatten.Insurance == "" {
+		return shim.Error("Insurance cannot not be Empty")
+	}
 	namespace := EXTRACTION_PATTERN_PREFIX
 	extPatternKey, _ := stub.CreateCompositeKey(namespace, []string{extractionPatten.ExtractionPatternID, extractionPatten.DbType})
 	extractionPatternAsBytes, err := stub.GetState(extPatternKey)
@@ -105,9 +107,9 @@ func (this *openIDLCC) UpdateExtractionPattern(stub shim.ChaincodeStubInterface,
 		return shim.Error("UpdateExtractionPattern: Failed to unmarshal pattern: " + err.Error())
 	}
 	prevExtractionPattern.PremiumFromDate = extractionPatten.PremiumFromDate
-    prevExtractionPattern.LossFromDate = extractionPatten.LossFromDate
-    prevExtractionPattern.Jurisdiction = extractionPatten.Jurisdiction
-    prevExtractionPattern.Insurance = extractionPatten.Insurance
+	prevExtractionPattern.LossFromDate = extractionPatten.LossFromDate
+	prevExtractionPattern.Jurisdiction = extractionPatten.Jurisdiction
+	prevExtractionPattern.Insurance = extractionPatten.Insurance
 	prevExtractionPattern.ViewDefinition = extractionPatten.ViewDefinition
 	prevExtractionPattern.UpdatedTs = extractionPatten.UpdatedTs
 	prevExtractionPattern.UpdatedBy = extractionPatten.UpdatedBy

--- a/openidl-chaincode/chaincode/openidl/insurance_data_controller.go
+++ b/openidl-chaincode/chaincode/openidl/insurance_data_controller.go
@@ -3,10 +3,12 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	pb "github.com/hyperledger/fabric/protos/peer"
 	"strconv"
 	"strings"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 )
 
 func (this *openIDLCC) SaveInsuranceDataHash(stub shim.ChaincodeStubInterface, args string) pb.Response {
@@ -28,7 +30,7 @@ func (this *openIDLCC) SaveInsuranceDataHash(stub shim.ChaincodeStubInterface, a
 	} else if insurance.ChunkId == "" {
 		return shim.Error("ChunkId should not be Empty")
 	}
-	
+
 	namespacePrefix := INSURANCE_HASH_PREFIX
 	//var pks []string = []string{INSURANCE_HASH_PREFIX, insurance.CarrierId, insurance.BatchId}
 	key, _ := stub.CreateCompositeKey(namespacePrefix, []string{insurance.CarrierId, insurance.BatchId, insurance.ChunkId})

--- a/openidl-chaincode/chaincode/openidl/insurance_data_controller_test.go
+++ b/openidl-chaincode/chaincode/openidl/insurance_data_controller_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	logger "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 //Test for SaveInsuranceHash

--- a/openidl-chaincode/chaincode/openidl/like_controller.go
+++ b/openidl-chaincode/chaincode/openidl/like_controller.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"strings"
+	logger "github.com/sirupsen/logrus"
 )
 
 // ToggleLike Creates and then toggles likes as a boolean value

--- a/openidl-chaincode/chaincode/openidl/main_router.go
+++ b/openidl-chaincode/chaincode/openidl/main_router.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 	//"strconv"
 )
 
@@ -17,7 +18,6 @@ type openIDLCC struct {
 	carriers map[string]Carrier
 }
 
-var logger = shim.NewLogger("openIDLCC_Logger")
 var crossInvocationChannels Channels
 
 // Init is called during chaincode instantiation to initialize any
@@ -30,10 +30,9 @@ func (this *openIDLCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
 
 	var logLevelConfig = os.Getenv(LOGGING_LEVEL)
 	if logLevelConfig != "" {
-		logLevel, _ := shim.LogLevel(logLevelConfig)
-		logger.SetLevel(logLevel)
+		logger.SetLevel(logLevelConfig)
 	} else {
-		logger.SetLevel(shim.LogInfo)
+		logger.SetLevel(logger.InfoLevel)
 	}
 
 	/*init_args := stub.GetStringArgs()

--- a/openidl-chaincode/chaincode/openidl/main_router_test.go
+++ b/openidl-chaincode/chaincode/openidl/main_router_test.go
@@ -5,6 +5,8 @@ import (
 	//"fmt"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
+
 	//"github.com/stretchr/testify/assert"
 	"os"
 	//"testing"
@@ -15,8 +17,6 @@ type openIDLTestCC struct {
 	carriers map[string]Carrier
 	openIDLCC
 }
-
-//var logger = shim.NewLogger("openIDLTestCC_Logger")
 
 func (this *openIDLTestCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
 	logger.Debug("Init: enter")

--- a/openidl-chaincode/chaincode/openidl/report_controller.go
+++ b/openidl-chaincode/chaincode/openidl/report_controller.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"strings"
+	logger "github.com/sirupsen/logrus"
 )
 
 // CreateReport creates a new report for a particular DataCall Id and version.

--- a/openidl-chaincode/chaincode/openidl/report_controller_test.go
+++ b/openidl-chaincode/chaincode/openidl/report_controller_test.go
@@ -3,11 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/stretchr/testify/assert"
-	"reflect"
+
 	//"strconv"
 	"testing"
+
+	logger "github.com/sirupsen/logrus"
 )
 
 // here we are implementing basic testing for the function ListReportsByCriteria

--- a/openidl-chaincode/chaincode/openidl/util.go
+++ b/openidl-chaincode/chaincode/openidl/util.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	pb "github.com/hyperledger/fabric/protos/peer"
+	logger "github.com/sirupsen/logrus"
 )
 
 // ToChaincodeArgs Prepare chaincode arguments for invoke chaincode


### PR DESCRIPTION
#11  As HL Fabric 2.x does not support shim logger anymore, updating the
logger to use open source library Logrus.

Signed-off-by: Adnan C <adnan.choudhury@itpeoplecorp.com>